### PR TITLE
Fixed to parse start_addres and stack_size parameter

### DIFF
--- a/msx_basic_compiler/msx_basic_compiler.cpp
+++ b/msx_basic_compiler/msx_basic_compiler.cpp
@@ -62,6 +62,7 @@ bool COPTIONS::parse_options( char *argv[], int argc ) {
 			}
 			else if( s == "-start" && (i + 1) != argc ) {
 				this->start_address = atoi( argv[i + 1] );
+				i++;
 				if( this->start_address < 32768 ) {
 					this->start_address = 32768;
 				}
@@ -71,6 +72,7 @@ bool COPTIONS::parse_options( char *argv[], int argc ) {
 			}
 			else if( s == "-stack" && (i + 1) != argc ) {
 				this->stack_size = atoi( argv[i + 1] );
+				i++;
 				if( this->stack_size < 0 ) {
 					this->stack_size = 0;
 				}


### PR DESCRIPTION
https://github.com/hra1129/msx_basic_compiler/issues/28

```sh
$ msx_bacon -start 32780 -stack 32 hello.bas hello_bas.asm 
MSX-BACON v0.0
=========================================================
Copyright (C)2023 t.hara
  Compile mode: MSX-BASIC Compatible.
  Optimization level: O2 (Code)
  Start address : 0x800C
  Stack size    : 32

Target: hello.bas (ASCII code).
Completed.
```
